### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
-AATR         KEYWORD1
-read         KEYWORD2
-getTmp       KEYWORD2
-toKelvin     KEYWORD2
-toCelcius    KEYWORD2
-toFahrenheit KEYWORD2
+AATR	KEYWORD1
+read	KEYWORD2
+getTmp	KEYWORD2
+toKelvin	KEYWORD2
+toCelcius	KEYWORD2
+toFahrenheit	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords